### PR TITLE
Add a testament parameter

### DIFF
--- a/src/scripts/source_quote_to_gl_via_alignment.js
+++ b/src/scripts/source_quote_to_gl_via_alignment.js
@@ -8,10 +8,11 @@ const {UWProskomma} = require('../../index');
 const pk = new UWProskomma();
 const args = process.argv.slice(2);
 const tsvPath = args[0];
-const prune = (args[1] === "prune") || false;
+const testament = args[1] // 'OT' or 'NT'
+const prune = (args[2] === "prune") || false;
 const book = tsvPath.split("/").reverse()[0].split(".")[0].split("-")[1];
 
-getDocuments(pk, book, true)
+getDocuments(pk, testament, book, true, false) //last parameters are "verbose" and "serialize"
     .then(async () => {
             // Query Proskomma which now contains the books
             // Returns the tokens for each verse, accessible by
@@ -27,8 +28,8 @@ getDocuments(pk, book, true)
                 console.log(`    Search string: ${tsvRecord.origQuote}`);
                 // Iterate over GLs
                 for (const gl of ["ult", "ust"]) {
-                    // Pick the right source for the book (inelegant but works)
-                    const source = tokenLookup.uhb || tokenLookup.ugnt;
+                    // Pick the right source for the book
+                    const source = testament === 'OT' ? tokenLookup.uhb : tokenLookup.ugnt;
                     // Get the tokens for BCV
                     const sourceTokens = source[book][cv];
                     const glTokens = tokenLookup[gl][book][cv];
@@ -39,6 +40,7 @@ getDocuments(pk, book, true)
                         sourceTokens,
                         glTokens,
                         tsvRecord.origQuote,
+                        tsvRecord.occurrence,
                         prune
                     );
                     // Returned object has either "data" or "error"

--- a/src/utils/download.js
+++ b/src/utils/download.js
@@ -1,12 +1,12 @@
 const Axios = require("axios");
 const YAML = require('js-yaml-parser');
 
-const getDocuments = async (pk, book, verbose, serialize) => {
-    const baseURLs = [
-        ["unfoldingWord", "hbo", "uhb", "https://git.door43.org/unfoldingWord/hbo_uhb/raw/branch/master"],
+const getDocuments = async (pk, testament, book, verbose, serialize) => {
+    const baseURLs = [testament === 'OT' ?
+        ["unfoldingWord", "hbo", "uhb", "https://git.door43.org/unfoldingWord/hbo_uhb/raw/branch/master"] :
         ["unfoldingWord", "grc", "ugnt", "https://git.door43.org/unfoldingWord/el-x-koine_ugnt/raw/branch/master"],
-        ["unfoldingWord", "en", "ust", "https://git.door43.org/unfoldingWord/en_ust/raw/branch/master"],
-        ["unfoldingWord", "en", "ult", "https://git.door43.org/unfoldingWord/en_ult/raw/branch/master"]
+    ["unfoldingWord", "en", "ust", "https://git.door43.org/unfoldingWord/en_ust/raw/branch/master"],
+    ["unfoldingWord", "en", "ult", "https://git.door43.org/unfoldingWord/en_ult/raw/branch/master"]
     ];
     verbose = verbose || false;
     serialize = serialize || false;
@@ -20,7 +20,7 @@ const getDocuments = async (pk, book, verbose, serialize) => {
         if (verbose) console.log(`  ${org}/${lang}/${abbr}`)
         const content = [];
         await Axios.request(
-            {method: "get", "url": `${baseURL}/manifest.yaml`}
+            { method: "get", "url": `${baseURL}/manifest.yaml` }
         )
             .then(
                 async response => {
@@ -34,7 +34,7 @@ const getDocuments = async (pk, book, verbose, serialize) => {
                         if (verbose) console.log(`    ${pathBook}`)
                         try {
                             await Axios.request(
-                                {method: "get", "url": `${baseURL}/${bookPath}`}
+                                { method: "get", "url": `${baseURL}/${bookPath}` }
                             )
                                 .then(response => {
                                     if (response.status !== 200) {
@@ -73,4 +73,4 @@ const getDocuments = async (pk, book, verbose, serialize) => {
     return pk;
 }
 
-module.exports = {getDocuments};
+module.exports = { getDocuments };

--- a/src/utils/search.js
+++ b/src/utils/search.js
@@ -17,7 +17,7 @@ const searchWordRecords = origString => {
     return ret.filter(t => t[0] !== "׀");
 }
 
-const contentForSearchWords = (searchTuples, tokens) => {
+const contentForSearchWords = (searchTuples, searchOccurrence, tokens) => {
 
     const lfsw1 = (searchTuples, tokens, content) => {
         if (!content) {
@@ -50,14 +50,14 @@ const highlightedAlignedGlText = (glTokens, content) => {
     )
 };
 
-const gl4Source = (book, cv, sourceTokens, glTokens, searchString, prune) => {
+const gl4Source = (book, cv, sourceTokens, glTokens, searchString, searchOccurrence, prune) => {
     const searchTuples = searchWordRecords(searchString);
-    const ugntTokens = slimSourceTokens(sourceTokens.filter(t => t.subType === "wordLike"));
-    const content = contentForSearchWords(searchTuples, ugntTokens);
+    const originalLanguageTokens = slimSourceTokens(sourceTokens.filter(t => t.subType === "wordLike"));
+    const content = contentForSearchWords(searchTuples, searchOccurrence, originalLanguageTokens);
     if (!content) {
         return {
             "error":
-                `NO MATCH IN SOURCE\nSearch Tuples: ${JSON.stringify(searchTuples)}\nCodepoints: ${searchTuples.map(s => "|" + Array.from(s[0]).map(c => c.charCodeAt(0).toString(16)))}`
+                `NO MATCH IN BIBLICAL LANGUAGE SOURCE\nSearch Tuples: ${JSON.stringify(searchTuples)}\nCodepoints: ${searchTuples.map(s => "|" + Array.from(s[0]).map(c => c.charCodeAt(0).toString(16)))}`
         }
     }
     const highlightedTokens = highlightedAlignedGlText(slimGLTokens(glTokens), content);


### PR DESCRIPTION
So it doesn't need to load both UHB and UGNT by default

This is the first of a number of changes that I needed to make in order to backport TSV7 TN to TSV9, i.e., to get GLQuote from OrigQuotes. So this is just a very simple PR to test the process. I don't know who else uses this code/repo?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-box3/uw-proskomma/1)
<!-- Reviewable:end -->
